### PR TITLE
Return the wrapped function's result from @with_app decorator

### DIFF
--- a/src/sphinx_testing/util.py
+++ b/src/sphinx_testing/util.py
@@ -159,7 +159,7 @@ class with_app(object):
                     app = TestApp(*self.sphinxargs, **sphinxkwargs)
                     self.write_docstring(app, func.__doc__)
 
-                    func(*(args + (app, status, warning)), **kwargs)
+                    return func(*(args + (app, status, warning)), **kwargs)
                 except Exception as _exc:
                     exc = _exc
                     raise

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -190,3 +190,12 @@ class TestSphinxTesting(unittest.TestCase):
             self.assertEqual('Hello world ', content)
 
         execute()
+
+    def test_with_app_return_value(self):
+        @with_app(create_new_srcdir=True)
+        def execute(ret, app, status, warning):
+            return ret
+
+        s = 'What goes in, must come out'
+
+        self.assertEqual(execute(s), s)


### PR DESCRIPTION
Allow @with_app to be used with functions that return a value.

Fixes #12.