### PR TITLE
replace nosetests with pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,13 +3,13 @@ envlist=py26,py27,py34,sphinx06,sphinx10,sphinx11,sphinx12,sphinx13,sphinx14,sph
 
 [testenv]
 deps=
-    nose
+    pytest
     mock
     flake8
 passenv=
     TRAVIS*
 commands=
-    nosetests
+    pytest
     flake8 setup.py src/ tests/
 
 [testenv:py26]
@@ -18,7 +18,7 @@ deps=
     unittest2
     Sphinx <= 1.4.9999
 commands=
-    nosetests
+    pytest
 
 [testenv:sphinx06]
 deps=


### PR DESCRIPTION
The following PR addresses issue #15 

The errors in tox are from Python versions I don't have, or in the case of Sphinx06 a problem with Sphinx itself.

```
ERROR:  py26: InterpreterNotFound: python2.6
  py27: commands succeeded
ERROR:  py34: InterpreterNotFound: python3.4
ERROR:   sphinx06: could not install deps [pytest, mock, flake8, Sphinx <= 0.6.9999]; v = InvocationError("/home/alfredo/python/sphinx-testing/.tox/sphinx06/bin/python -m pip install pytest mock flake8 'Sphinx <= 0.6.9999'", 1)
ERROR:   sphinx10: could not install deps [pytest, mock, flake8, Sphinx <= 1.0.9999]; v = InvocationError("/home/alfredo/python/sphinx-testing/.tox/sphinx10/bin/python -m pip install pytest mock flake8 'Sphinx <= 1.0.9999'", 1)
  sphinx11: commands succeeded
  sphinx12: commands succeeded
  sphinx13: commands succeeded
  sphinx14: commands succeeded
  sphinx15: commands succeeded
  sphinx16: commands succeeded
  sphinx17: commands succeeded
  sphinx18: commands succeeded
  sphinx-dev: commands succeeded
```